### PR TITLE
Disable download_resources target in build.xml

### DIFF
--- a/build
+++ b/build
@@ -33,6 +33,12 @@ sed -i "s/\"OsmAnd+\"/\"$OSMAND_APPNAME\"/g" build.xml || err "Could not replace
 # Build native code
 ./old-ndk-build.sh || err "Failed to build native code"
 
+# Do not use download_resources target:
+sed  -i -e '/target name=\"-pre-build\"/s/download_resources,//' -i build.xml
+
+# Download wrapper (TODO: build wrapper by ourselves)
+wget http://builder.osmand.net:81/binaries/android/OsmAndCore_wrapper.jar -O libs/OsmAndCore_wrapper.jar
+
 # Build the rest
 ant \
 	-Dsdk.dir="$ANDROID_SDK" \


### PR DESCRIPTION
Download the SWIG wrapper for the time being till we find out how to
generate it